### PR TITLE
.bash_history files securely deleted.

### DIFF
--- a/redghost.sh
+++ b/redghost.sh
@@ -354,8 +354,10 @@ escalate(){
 clearlog(){
 	export HISTFILE=
 	unset HISTFILE
-	rm -rf ~/.bash_history
+	shred -zu ~/.bash_history
 	touch ~/.bash_history
+	find /home/ -name ".bash_history" -exec shred -zu {} \; -exec touch {} \;
+	history -c
 	unset HISTFILE HISTSIZE
 	set history=0
 	set +o history


### PR DESCRIPTION
.bash_history files securely deleted.

Files that contain sensitive data, we might use **Shred** that overwrites the file multiple times. **Rm** doesn't actually do anything to the data on disk. For this reason, I added the following codes.

```
shred -zu ~/.bash_history
find /home/ -name ".bash_history" -exec shred -zu {} \; -exec touch {} \;
history -c
```
